### PR TITLE
Get errors from async-tasks #44

### DIFF
--- a/evaluator/evaluator/app/models.py
+++ b/evaluator/evaluator/app/models.py
@@ -92,6 +92,15 @@ class MultipleChoiceDatasetSample(BaseModel):
     )
 
 
+class TaskResponse(BaseModel):
+    task_id: str = Field(..., description="ID of the task.")
+    state: str = Field(..., description="Current state of the task.")
+    finished: Optional[datetime] = Field(
+        None, description="Date when the task finished processing."
+    )
+    result: Optional[str] = Field(None, description="Result of the task.")
+
+
 # Mocked function. Remove after https://github.com/nclskfm/square-core/issues/7 is implemented.
 def get_dataset_metadata(dataset_name):
     if dataset_name == "squad":

--- a/evaluator/evaluator/app/routers/api.py
+++ b/evaluator/evaluator/app/routers/api.py
@@ -3,9 +3,11 @@ from fastapi import APIRouter
 from evaluator.app.routers.dataset import router as dataset_router
 from evaluator.app.routers.evaluator import router as evaluator_router
 from evaluator.app.routers.predictor import router as predictor_router
+from evaluator.app.routers.task import router as task_router
 
 router = APIRouter()
 
 router.include_router(dataset_router)
+router.include_router(task_router)
 router.include_router(evaluator_router)
 router.include_router(predictor_router)

--- a/evaluator/evaluator/app/routers/dataset.py
+++ b/evaluator/evaluator/app/routers/dataset.py
@@ -1,12 +1,9 @@
 import logging
 from typing import List
 
-from celery.result import AsyncResult
 from fastapi import APIRouter
 
 from evaluator.app.models import DataSet
-from evaluator.tasks import tasks
-from evaluator.tasks.celery import app as celery_app
 
 logger = logging.getLogger(__name__)
 
@@ -23,44 +20,3 @@ async def get_datasets():
 
     logger.debug("get_datasets {datasets}".format(datasets=datasets))
     return datasets
-
-
-@router.get("/start-task", name="")
-async def start_test_task():
-    res = tasks.test_something.delay()
-    return res.id
-
-
-@router.get("/show-tasks", name="")
-async def get_all_tasks():
-    # https://docs.celeryq.dev/en/latest/userguide/workers.html#inspecting-workers
-    i = celery_app.control.inspect()
-    # Show the items that have an ETA or are scheduled for later processing
-    scheduled = i.scheduled()
-
-    # Show tasks that are currently active.
-    active = i.active()
-
-    # Show tasks that have been claimed by workers
-    reserved = i.reserved()
-
-    tasks = {
-        "scheduled": scheduled,
-        "active": active,
-        "reserved": reserved,
-    }
-
-    logger.info("/tasks: {}".format(tasks))
-
-    return tasks
-
-
-@router.get("/task_result/{task_id}", name="")
-async def get_task_status(task_id):
-    task = AsyncResult(task_id)
-    if task.failed():
-        return "Task failed"
-    if not task.ready():
-        return "Task still processing"
-    result = task.get()
-    return {"task_id": str(task.id), "finished": str(task.date_done), "result": result}

--- a/evaluator/evaluator/app/routers/evaluator.py
+++ b/evaluator/evaluator/app/routers/evaluator.py
@@ -48,7 +48,7 @@ async def evaluate(
     token: str = Depends(client_credentials),
     _token_payload: Dict = Depends(auth),
 ):
-    logger.debug(
+    logger.info(
         f"Requested evaluation-task for skill '{skill_id}' on dataset '{dataset_name}' with metric '{metric_name}'"
     )
 
@@ -88,7 +88,7 @@ async def evaluate(
         args=(skill_id, dataset_name, metric_name),
         task_id=task_id("evaluate", skill_id, dataset_name, metric_name),
     )
-    logger.debug(
+    logger.info(
         f"Created evaluation-task for skill '{skill_id}' on dataset '{dataset_name}' and metric '{metric_name}'. Task-ID: '{task.id}'"
     )
 

--- a/evaluator/evaluator/app/routers/predictor.py
+++ b/evaluator/evaluator/app/routers/predictor.py
@@ -35,7 +35,7 @@ async def predict(
     token: str = Depends(client_credentials),
     _token_payload: Dict = Depends(auth),
 ):
-    logger.debug(
+    logger.info(
         f"Requested prediction-task for skill '{skill_id}' on dataset '{dataset_name}'"
     )
 
@@ -55,7 +55,7 @@ async def predict(
         args=(skill_id, dataset_name, token),
         task_id=task_id("predict", skill_id, dataset_name),
     )
-    logger.debug(
+    logger.info(
         f"Created prediction-task for skill '{skill_id}' on dataset '{dataset_name}'. Task-ID: '{task.id}'"
     )
 

--- a/evaluator/evaluator/app/routers/task.py
+++ b/evaluator/evaluator/app/routers/task.py
@@ -1,0 +1,53 @@
+import logging
+from typing import List
+
+from celery.result import AsyncResult
+from fastapi import APIRouter
+
+from evaluator.app.models import TaskResponse
+from evaluator.tasks.celery import app as celery_app
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/task")
+
+
+@router.get("", name="Get current tasks")
+async def get_tasks():
+    # https://docs.celeryq.dev/en/latest/userguide/workers.html#inspecting-workers
+    i = celery_app.control.inspect()
+    scheduled = i.scheduled()
+    active = i.active()
+    reserved = i.reserved()
+
+    tasks = {
+        "scheduled": scheduled,
+        "active": active,
+        "reserved": reserved,
+    }
+    logger.info("/tasks: {}".format(tasks))
+
+    return tasks
+
+
+@router.get("/{task_id}", name="Get single task result")
+async def get_task(task_id):
+    task = AsyncResult(task_id)
+    if not task.ready():
+        return task_response(task)
+    elif task.failed():
+        error = task.get(propagate=False)
+        logger.error(f"Task '{task_id}' failed: {error!r}")
+        return task_response(task, f"{error}")
+    else:
+        result = task.get()
+        return task_response(task, result)
+
+
+def task_response(task, result=None) -> TaskResponse:
+    return TaskResponse(
+        task_id=str(task.id),
+        state=task.state,
+        finished=task.date_done,
+        result=str(result) if not result is None else result,
+    )

--- a/evaluator/evaluator/tasks/celery.py
+++ b/evaluator/evaluator/tasks/celery.py
@@ -18,7 +18,6 @@ app = Celery(
     backend=f"redis://{redis_user}:{redis_password}@{redis_host}:6379",
     broker=f"amqp://{rabbitmq_user}:{rabbitmq_password}@rabbit:5672//",
     include=[
-        "evaluator.tasks.tasks",
         "evaluator.tasks.predict_task",
         "evaluator.tasks.evaluate_task",
     ],

--- a/evaluator/evaluator/tasks/tasks.py
+++ b/evaluator/evaluator/tasks/tasks.py
@@ -1,9 +1,0 @@
-import time
-
-from .celery import app as celery_app
-
-
-@celery_app.task
-def test_something():
-    time.sleep(15)
-    return "This is the result of the test task"


### PR DESCRIPTION
Errors occurring within prediction and evaluation tasks are now returned as the tasks result (if status=FAILED).
Prediction and evaluation tasks will now return results on success. Improved logging and errors.
Removed tasks that were used for testing.